### PR TITLE
use `os.tmpdir()` polyfill for more consistent behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 
 var path = require('path')
-var os = require('os')
-
-var tmpdir = os.tmpdir ? os.tmpdir() : os.tmpDir()
+var tmpdir = require('os-tmpdir')()
 
 module.exports = function () {
   return path.join(tmpdir, random() + random())

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   ],
   "files": [
     "index.js"
-  ]
+  ],
+  "dependencies": {
+    "os-tmpdir": "^1.0.0"
+  }
 }


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions and it would be nice for users if it were consistent between Node versions. This might even prevent hard to track down bugs.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.1: https://github.com/iojs/io.js/blob/6c80e38b014b7be570ffafa91032a6d67d7dd4ae/lib/os.js#L25-L40

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform
> 
> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir
